### PR TITLE
Map form + additional validations + refactor

### DIFF
--- a/example/validation/main.go
+++ b/example/validation/main.go
@@ -41,7 +41,7 @@ func isHexColor(val any, field reflect.StructField) (out form.FieldErrors) {
 type CustomForm struct {
 	form.Info
 	Name  string `form:"input,text" label:"Name" required:"true" minLength:"2" maxLength:"20"`
-	Color string `form:"input,text" label:"Favorite Color (hex)" validate:"isHexColor"`
+	Color string `form:"input,color" label:"Favorite Color (hex)" validate:"isHexColor"`
 }
 
 func main() {
@@ -83,7 +83,6 @@ func main() {
 				<a href="http://localhost:8082/">Translation Example</a>
 			</div>
 			{{ form_render .Form .Errors }}
-
 			</body>
 			</html>
 		`))

--- a/example/validation/main.go
+++ b/example/validation/main.go
@@ -51,20 +51,20 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		data := CustomForm{
 			Info: form.Info{
-				Target: r.URL.Path,
-				Method: http.MethodPost,
+				Target:     r.URL.Path,
+				Method:     http.MethodPost,
+				SubmitText: "Submit",
 			},
 		}
 
 		var errs form.FieldErrors
 		if r.Method == http.MethodPost {
-			err := r.ParseForm()
+			err := form.MapForm(r, &data)
 			if err != nil {
-				http.Error(w, "Error parsing form: "+err.Error(), http.StatusBadRequest)
+				http.Error(w, "Error mapping form: "+err.Error(), http.StatusBadRequest)
 				return
 			}
-			data.Name = r.FormValue("Name")
-			data.Color = r.FormValue("Color")
+
 			errs = f.ValidateForm(&data, nil)
 		}
 

--- a/form.go
+++ b/form.go
@@ -85,13 +85,12 @@ func (f *Form) init(templateMap map[types.FieldType]map[types.InputFieldType]str
 
 			// Create a new template with the base template defined
 			t := template.New(inputType.String())
-			t, err := t.Funcs(map[string]any{
+			t, tErr := t.Funcs(map[string]any{
 				"errors": func() []string { return nil },     // Placeholder for error handling
 				"field":  func() template.HTML { return "" }, // Placeholder for field rendering
 				"fields": func() template.HTML { return "" }, // Placeholder for group fields
 				"label":  func() template.HTML { return "" }, // Placeholder for label rendering
 				"form_print": func(loc Localizer, key string, args ...any) string {
-					fmt.Println("form_print called with key:(", key, ") args:", args)
 					if f.translationEnabled && f.translationFunc != nil {
 						return f.translationFunc(loc, key, args...)
 					}
@@ -121,15 +120,15 @@ func (f *Form) init(templateMap map[types.FieldType]map[types.InputFieldType]str
 					}
 
 					var sb strings.Builder
-					err := baseInputTpl.Execute(&sb, data)
-					if err != nil {
-						panic(err) // Handle error appropriately in production code
+					eErr := baseInputTpl.Execute(&sb, data)
+					if eErr != nil {
+						return template.HTML(fmt.Sprintf("error executing base input template: %+v", eErr))
 					}
 					return template.HTML(sb.String())
 				},
 			}).Parse(tpl)
-			if err != nil {
-				panic(err) // Handle error appropriately in production code
+			if tErr != nil {
+				panic(fmt.Errorf("error parsing template for field type %s and input type %s: %w", fieldType, inputType, tErr))
 			}
 			f.templateMap[fieldType][inputType] = *t
 		}

--- a/form.go
+++ b/form.go
@@ -91,6 +91,7 @@ func (f *Form) init(templateMap map[types.FieldType]map[types.InputFieldType]str
 				"fields": func() template.HTML { return "" }, // Placeholder for group fields
 				"label":  func() template.HTML { return "" }, // Placeholder for label rendering
 				"form_print": func(loc Localizer, key string, args ...any) string {
+					fmt.Println("form_print called with key:(", key, ") args:", args)
 					if f.translationEnabled && f.translationFunc != nil {
 						return f.translationFunc(loc, key, args...)
 					}

--- a/map.go
+++ b/map.go
@@ -1,0 +1,84 @@
+package form
+
+import (
+	"net/http"
+	"reflect"
+	"strconv"
+)
+
+var (
+	ErrMapFormNotPointer = &MapFormError{"dst must be a pointer to struct"}
+	ErrMapFormNotStruct  = &MapFormError{"dst must be a pointer to struct"}
+)
+
+// MapForm maps form values from an http.Request to a struct based on the `name` tag.
+// Only exported fields are set. Supports string, int, float64, and bool fields.
+func MapForm(r *http.Request, dst any, prefixes ...string) error {
+	v := reflect.ValueOf(dst)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return ErrMapFormNotPointer
+	}
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		return ErrMapFormNotStruct
+	}
+	prefix := ""
+	if len(prefixes) > 0 {
+		prefix = prefixes[0]
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fv := v.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+
+		// Recursively map nested structs (skip special types)
+		if fv.Kind() == reflect.Struct {
+			if fv.CanAddr() {
+				name := field.Tag.Get("name")
+				if name == "" {
+					name = field.Name
+				}
+
+				_ = MapForm(r, fv.Addr().Interface(), prefix+name+".")
+			}
+			continue
+		}
+		formKey := field.Tag.Get("name")
+		if formKey == "" {
+			formKey = field.Name
+		}
+		formValue := r.FormValue(prefix + formKey)
+		if formValue == "" {
+			continue
+		}
+
+		switch fv.Kind() {
+		case reflect.String:
+			fv.SetString(formValue)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if iv, err := strconv.ParseInt(formValue, 10, 64); err == nil {
+				fv.SetInt(iv)
+			}
+		case reflect.Float32, reflect.Float64:
+			if fv64, err := strconv.ParseFloat(formValue, 64); err == nil {
+				fv.SetFloat(fv64)
+			}
+		case reflect.Bool:
+			if bv, err := strconv.ParseBool(formValue); err == nil {
+				fv.SetBool(bv)
+			}
+		}
+	}
+	return nil
+}
+
+type MapFormError struct {
+	msg string
+}
+
+func (e *MapFormError) Error() string {
+	return e.msg
+}

--- a/map_test.go
+++ b/map_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 type testStruct struct {
-	Name   string  `form:"name"`
-	Age    int     `form:"age"`
-	Active bool    `form:"active"`
-	Score  float64 `form:"score"`
-	Note   string  // no tag, should use field name
+	Name   string
+	Age    int
+	Active bool
+	Score  float64
+	Note   string
 }
 
 func TestMapForm(t *testing.T) {
 	form := url.Values{}
-	form.Set("name", "Alice")
-	form.Set("age", "30")
-	form.Set("active", "true")
-	form.Set("score", "99.5")
+	form.Set("Name", "Alice")
+	form.Set("Age", "30")
+	form.Set("Active", "true")
+	form.Set("Score", "99.5")
 	form.Set("Note", "Hello")
 
 	r := &http.Request{Form: form}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,97 @@
+package form
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type testStruct struct {
+	Name   string  `form:"name"`
+	Age    int     `form:"age"`
+	Active bool    `form:"active"`
+	Score  float64 `form:"score"`
+	Note   string  // no tag, should use field name
+}
+
+func TestMapForm(t *testing.T) {
+	form := url.Values{}
+	form.Set("name", "Alice")
+	form.Set("age", "30")
+	form.Set("active", "true")
+	form.Set("score", "99.5")
+	form.Set("Note", "Hello")
+
+	r := &http.Request{Form: form}
+
+	var s testStruct
+	err := MapForm(r, &s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if s.Name != "Alice" {
+		t.Errorf("expected Name 'Alice', got '%s'", s.Name)
+	}
+	if s.Age != 30 {
+		t.Errorf("expected Age 30, got %d", s.Age)
+	}
+	if !s.Active {
+		t.Errorf("expected Active true, got false")
+	}
+	if s.Score != 99.5 {
+		t.Errorf("expected Score 99.5, got %f", s.Score)
+	}
+	if s.Note != "Hello" {
+		t.Errorf("expected Note 'Hello', got '%s'", s.Note)
+	}
+}
+
+func TestMapFormErrors(t *testing.T) {
+	var s testStruct
+	err := MapForm(nil, s) // not a pointer
+	if err == nil {
+		t.Error("expected error for non-pointer dst")
+	}
+
+	err = MapForm(nil, &struct{}{}) // nil request, but should not panic
+	if err != nil {
+		t.Errorf("unexpected error for nil request: %v", err)
+	}
+}
+
+type nestedStruct struct {
+	City string
+	Zip  int
+}
+
+type parentStruct struct {
+	Name   string
+	Nested nestedStruct
+}
+
+func TestMapFormNestedStruct(t *testing.T) {
+	form := url.Values{}
+	form.Set("Name", "Bob")
+	form.Set("Nested.City", "Amsterdam")
+	form.Set("Nested.Zip", "12345")
+
+	r := &http.Request{Form: form}
+
+	var s parentStruct
+	err := MapForm(r, &s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Name != "Bob" {
+		t.Errorf("expected Name 'Bob', got '%s'", s.Name)
+	}
+
+	if s.Nested.City != "Amsterdam" {
+		t.Errorf("expected Nested.City 'Amsterdam', got '%s'", s.Nested.City)
+	}
+
+	if s.Nested.Zip != 12345 {
+		t.Errorf("expected Nested.Zip 12345, got %d", s.Nested.Zip)
+	}
+}

--- a/templates/bootstrapV5.go
+++ b/templates/bootstrapV5.go
@@ -71,9 +71,6 @@ var BootstrapV5 = map[types.FieldType]map[types.InputFieldType]string{
 	types.FieldTypeTextArea: {
 		types.InputFieldTypeNone: `<div class="position-relative">
   <textarea class="form-control form-control-sm" id="{{.Field.Id}}" name="{{.Field.Name}}" rows="{{.Field.Rows}}" cols="{{.Field.Cols}}" placeholder="{{.Field.Placeholder}}" {{ if eq .Field.Required true }}required{{end}} aria-labelledby="{{.Field.Id}}_label" {{if .Field.Description}}aria-describedby="{{.Field.Id}}_description"{{end}}>{{.Field.Value}}</textarea>
-  {{ if .Field.MaxLength }}
-  <div class="position-absolute bottom-0 end-0 mb-2 me-2 small text-muted" id="{{.Field.Id}}_count" aria-hidden="true">0/{{.Field.MaxLength}}</div>
-  {{ end }}
 </div>`,
 	},
 	types.FieldTypeGroup: {

--- a/templates/plain.go
+++ b/templates/plain.go
@@ -69,9 +69,6 @@ var Plain = map[types.FieldType]map[types.InputFieldType]string{
 	types.FieldTypeTextArea: {
 		types.InputFieldTypeNone: `<div style="position: relative;">
   <textarea id="{{.Field.Id}}" name="{{.Field.Name}}" rows="{{.Field.Rows}}" cols="{{.Field.Cols}}" placeholder="{{ form_print .Loc .Field.Placeholder}}" {{ if eq .Field.Required true }}required{{end}} style="width: 100%; padding: 0.375rem 0.75rem; font-size: 0.875rem; line-height: 1.5; color: #212529; background-color: #fff; border: 1px solid #ced4da; border-radius: 0.25rem; transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;" aria-labelledby="{{.Field.Id}}_label" {{if .Field.Description}}aria-describedby="{{.Field.Id}}_description"{{end}}>{{.Field.Value}}</textarea>
-  {{ if .Field.MaxLength }}
-  <div style="position: absolute; bottom: 0.5rem; right: 0.5rem; font-size: 0.75rem; color: #6c757d;" id="{{.Field.Id}}_count" aria-hidden="true">0/{{.Field.MaxLength}}</div>
-  {{ end }}
 </div>`,
 	},
 	types.FieldTypeGroup: {

--- a/templates/tailwindV3.go
+++ b/templates/tailwindV3.go
@@ -69,9 +69,6 @@ var TailwindV3 = map[types.FieldType]map[types.InputFieldType]string{
 	types.FieldTypeTextArea: {
 		types.InputFieldTypeNone: `<div class="relative">
   <textarea id="{{.Field.Id}}" name="{{.Field.Name}}" rows="{{.Field.Rows}}" cols="{{.Field.Cols}}" placeholder="{{.Field.Placeholder}}" {{ if eq .Field.Required true }}required{{end}} class="border border-gray-200 block w-full rounded-md px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" aria-labelledby="{{.Field.Id}}_label" {{if .Field.Description}}aria-describedby="{{.Field.Id}}_description"{{end}}>{{.Field.Value}}</textarea>
-  {{ if .Field.MaxLength }}
-  <div class="absolute bottom-2 right-2 text-xs text-gray-500" id="{{.Field.Id}}_count" aria-hidden="true">0/{{.Field.MaxLength}}</div>
-  {{ end }}
 </div>`,
 	},
 	types.FieldTypeGroup: {

--- a/transformer.go
+++ b/transformer.go
@@ -26,6 +26,8 @@ const (
 	tagDescription = "description"
 )
 
+var DefaultSubmitText = "Submit"
+
 type (
 	Enumerator interface{ Enum() []any }
 	Mapper     interface {
@@ -92,11 +94,16 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 	if rType.Field(0).Anonymous && rType.Field(0).Type == reflect.TypeOf(Info{}) {
 		info := rValue.Field(0).Interface().(Info)
 
+		label := info.SubmitText
+		if label == "" {
+			label = DefaultSubmitText
+		}
+
 		formField := types.FormField{
 			Type:   types.FieldTypeForm,
 			Target: info.Target,
 			Method: info.Method,
-			Label:  info.SubmitText,
+			Label:  label,
 		}
 
 		fields = append(fields, formField)

--- a/validation.go
+++ b/validation.go
@@ -46,6 +46,235 @@ func (e FieldValidationError) FieldError() (field, err string) {
 	return e.Field, e.Err
 }
 
+// Helper functions for each validation type
+func validateRequired(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	req := field.Tag.Get("required")
+	if req == "true" {
+		if isEmptyValue(value) {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyRequired, nil)})
+		}
+	}
+	return
+}
+
+func validateMinMax(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.Kind() == reflect.Int || value.Kind() == reflect.Float64 {
+		var val float64
+		if value.Kind() == reflect.Int {
+			val = float64(value.Int())
+		} else {
+			val = value.Float()
+		}
+		if minTag := field.Tag.Get("min"); minTag != "" {
+			minVal, _ := strconv.ParseFloat(minTag, 64)
+			if val < minVal {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMin, minVal)})
+			}
+		}
+		if maxTag := field.Tag.Get("max"); maxTag != "" {
+			maxVal, _ := strconv.ParseFloat(maxTag, 64)
+			if val > maxVal {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMax, maxVal)})
+			}
+		}
+	}
+	return
+}
+
+func validateStep(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if stepTag := field.Tag.Get("step"); stepTag != "" && (value.Kind() == reflect.Int || value.Kind() == reflect.Float64) {
+		step, err := strconv.ParseFloat(stepTag, 64)
+		var val float64
+		if value.Kind() == reflect.Int {
+			val = float64(value.Int())
+		} else {
+			val = value.Float()
+		}
+		if err == nil && step > 0 {
+			mod := val / step
+			if mod != float64(int64(mod)) {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyStep, step)})
+			}
+		}
+	}
+	return
+}
+
+func validateLength(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.Kind() == reflect.String {
+		if maxLength := field.Tag.Get("maxLength"); maxLength != "" {
+			maxLen, err := strconv.Atoi(maxLength)
+			if err == nil && utf8.RuneCountInString(value.String()) > maxLen {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMaxLength, maxLen)})
+			}
+		}
+		if minLength := field.Tag.Get("minLength"); minLength != "" {
+			minLen, err := strconv.Atoi(minLength)
+			if err == nil && utf8.RuneCountInString(value.String()) < minLen {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMinLength, minLen)})
+			}
+		}
+	}
+	return
+}
+
+func validatePattern(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if pattern := field.Tag.Get("pattern"); pattern != "" && value.Kind() == reflect.String {
+		matched, err := regexp.MatchString(pattern, value.String())
+		if err == nil && !matched {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyPattern, pattern)})
+		}
+	}
+	return
+}
+
+func validateURL(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if field.Tag.Get("url") == "true" && value.Kind() == reflect.String {
+		str := value.String()
+		if str != "" {
+			_, err := url.ParseRequestURI(str)
+			if err != nil {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyURL, nil)})
+			}
+		}
+	}
+	return
+}
+
+func validateBool(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if field.Tag.Get("bool") == "true" && value.Kind() == reflect.Bool {
+		if !value.Bool() {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyBool, nil)})
+		}
+	}
+	return
+}
+
+func validateZero(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if field.Tag.Get("zero") == "true" {
+		if !isEmptyValue(value) {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyZero, nil)})
+		}
+	}
+	return
+}
+
+func validateSliceArrayLength(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
+		if minItems := field.Tag.Get("minItems"); minItems != "" {
+			min, err := strconv.Atoi(minItems)
+			if err == nil && value.Len() < min {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMinItems, min)})
+			}
+		}
+		if maxItems := field.Tag.Get("maxItems"); maxItems != "" {
+			max, err := strconv.Atoi(maxItems)
+			if err == nil && value.Len() > max {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyMaxItems, max)})
+			}
+		}
+	}
+	return
+}
+
+func validatePrefixSuffixContains(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.Kind() == reflect.String {
+		str := value.String()
+		if prefix := field.Tag.Get("prefix"); prefix != "" {
+			if !strings.HasPrefix(str, prefix) {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyPrefix, prefix)})
+			}
+		}
+		if suffix := field.Tag.Get("suffix"); suffix != "" {
+			if !strings.HasSuffix(str, suffix) {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeySuffix, suffix)})
+			}
+		}
+		if contains := field.Tag.Get("contains"); contains != "" {
+			if !strings.Contains(str, contains) {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyContains, contains)})
+			}
+		}
+	}
+	return
+}
+
+func validateValues(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if vals := field.Tag.Get("values"); vals != "" && value.Kind() == reflect.String {
+		allowed := map[string]struct{}{}
+		for _, v := range strings.Split(vals, ";") {
+			if strings.Contains(v, ":") {
+				parts := strings.SplitN(v, ":", 2)
+				allowed[strings.TrimSpace(parts[0])] = struct{}{}
+			} else {
+				allowed[strings.TrimSpace(v)] = struct{}{}
+			}
+		}
+		if value.String() != "" {
+			if _, ok := allowed[value.String()]; !ok {
+				errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyInvalidValue, value.String())})
+			}
+		}
+	}
+	return
+}
+
+func validateEmail(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if field.Tag.Get("form") == "input,email" && value.Kind() == reflect.String {
+		if val := value.String(); val != "" && !strings.Contains(val, "@") {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyInvalidEmail, nil)})
+		}
+	}
+	return
+}
+
+func validateEnum(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.IsValid() && value.Type().Implements(reflect.TypeOf((*Enumerator)(nil)).Elem()) {
+		enumVals := value.Interface().(Enumerator).Enum()
+		valStr := fmt.Sprint(value.Interface())
+		found := false
+		for _, v := range enumVals {
+			if fmt.Sprint(v) == valStr {
+				found = true
+				break
+			}
+		}
+		if !found && valStr != "" {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyInvalidEnum, valStr)})
+		}
+	}
+	return
+}
+
+func validateMapper(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.IsValid() && value.Type().Implements(reflect.TypeOf((*Mapper)(nil)).Elem()) {
+		maps := value.Interface().(Mapper).Mapper()
+		valStr := fmt.Sprint(value.Interface())
+		if _, ok := maps[valStr]; !ok && valStr != "" {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyInvalidMapper, valStr)})
+		}
+	}
+	return
+}
+
+func validateSortedMapper(f *Form, field reflect.StructField, value reflect.Value, loc Localizer, getErr func(string, any) string) (errs FieldErrors) {
+	if value.IsValid() && value.Type().Implements(reflect.TypeOf((*SortedMapper)(nil)).Elem()) {
+		smaps := value.Interface().(SortedMapper).SortedMapper()
+		valStr := fmt.Sprint(value.Interface())
+		found := false
+		for _, sm := range smaps {
+			if sm.Key() == valStr {
+				found = true
+				break
+			}
+		}
+		if !found && valStr != "" {
+			errs = append(errs, FieldValidationError{Field: field.Name, Err: getErr(TranslationKeyInvalidSortedMapper, valStr)})
+		}
+	}
+	return
+}
+
 // internalFormValidation validates struct fields based on struct tags.
 // Returns FieldErrors a slice or FieldError.
 func (f *Form) internalFormValidation(form any, loc Localizer) FieldErrors {
@@ -58,7 +287,6 @@ func (f *Form) internalFormValidation(form any, loc Localizer) FieldErrors {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		value := v.Field(i)
-		name := field.Name
 
 		// Custom error message
 		errorMsg := field.Tag.Get("errorMsg")
@@ -69,195 +297,36 @@ func (f *Form) internalFormValidation(form any, loc Localizer) FieldErrors {
 			return f.validationErrorTranslated(loc, defaultKey, arg)
 		}
 
-		// Required
-		req := field.Tag.Get("required")
-		if req == "true" {
-			if isEmptyValue(value) {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyRequired, nil)})
-			}
-		}
-
-		// Min/Max/Step for numbers
-		if value.Kind() == reflect.Int || value.Kind() == reflect.Float64 {
-			var val float64
-			if value.Kind() == reflect.Int {
-				val = float64(value.Int())
-			} else {
-				val = value.Float()
-			}
-			if minTag := field.Tag.Get("min"); minTag != "" {
-				minVal, _ := strconv.ParseFloat(minTag, 64)
-				if val < minVal {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMin, minVal)})
-				}
-			}
-			if maxTag := field.Tag.Get("max"); maxTag != "" {
-				maxVal, _ := strconv.ParseFloat(maxTag, 64)
-				if val > maxVal {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMax, maxVal)})
-				}
-			}
-			if stepTag := field.Tag.Get("step"); stepTag != "" {
-				step, err := strconv.ParseFloat(stepTag, 64)
-				if err == nil && step > 0 {
-					mod := val / step
-					if mod != float64(int64(mod)) {
-						errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyStep, step)})
-					}
-				}
-			}
-		}
-
-		// maxLength for strings and textareas
-		if (value.Kind() == reflect.String) && field.Tag.Get("maxLength") != "" {
-			maxLen, err := strconv.Atoi(field.Tag.Get("maxLength"))
-			if err == nil && utf8.RuneCountInString(value.String()) > maxLen {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMaxLength, maxLen)})
-			}
-		}
-
-		// minLength for strings and textareas
-		if (value.Kind() == reflect.String) && field.Tag.Get("minLength") != "" {
-			minLen, err := strconv.Atoi(field.Tag.Get("minLength"))
-			if err == nil && utf8.RuneCountInString(value.String()) < minLen {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMinLength, minLen)})
-			}
-		}
-
-		// values check for radios/dropdowns
-		if vals := field.Tag.Get("values"); vals != "" && value.Kind() == reflect.String {
-			allowed := map[string]struct{}{}
-			for _, v := range strings.Split(vals, ";") {
-				if strings.Contains(v, ":") {
-					parts := strings.SplitN(v, ":", 2)
-					allowed[strings.TrimSpace(parts[0])] = struct{}{}
-				} else {
-					allowed[strings.TrimSpace(v)] = struct{}{}
-				}
-			}
-			if value.String() != "" {
-				if _, ok := allowed[value.String()]; !ok {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyInvalidValue, value.String())})
-				}
-			}
-		}
-
-		// Email format (simple check)
-		if field.Tag.Get("form") == "input,email" && value.Kind() == reflect.String {
-			if val := value.String(); val != "" && !strings.Contains(val, "@") {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyInvalidEmail, nil)})
-			}
-		}
-
-		// Enumerator validation
-		if value.IsValid() && value.Type().Implements(reflect.TypeOf((*Enumerator)(nil)).Elem()) {
-			enumVals := value.Interface().(Enumerator).Enum()
-			valStr := fmt.Sprint(value.Interface())
-			found := false
-			for _, v := range enumVals {
-				if fmt.Sprint(v) == valStr {
-					found = true
-					break
-				}
-			}
-			if !found && valStr != "" {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyInvalidEnum, valStr)})
-			}
-		}
-
-		// Mapper validation
-		if value.IsValid() && value.Type().Implements(reflect.TypeOf((*Mapper)(nil)).Elem()) {
-			maps := value.Interface().(Mapper).Mapper()
-			valStr := fmt.Sprint(value.Interface())
-			if _, ok := maps[valStr]; !ok && valStr != "" {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyInvalidMapper, valStr)})
-			}
-		}
-
-		// SortedMapper validation
-		if value.IsValid() && value.Type().Implements(reflect.TypeOf((*SortedMapper)(nil)).Elem()) {
-			smaps := value.Interface().(SortedMapper).SortedMapper()
-			valStr := fmt.Sprint(value.Interface())
-			found := false
-			for _, sm := range smaps {
-				if sm.Key() == valStr {
-					found = true
-					break
-				}
-			}
-			if !found && valStr != "" {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyInvalidSortedMapper, valStr)})
-			}
-		}
-
-		// Pattern/Regex validation
-		if pattern := field.Tag.Get("pattern"); pattern != "" && value.Kind() == reflect.String {
-			matched, err := regexp.MatchString(pattern, value.String())
-			if err == nil && !matched {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyPattern, pattern)})
-			}
-		}
-
-		// URL validation
-		if field.Tag.Get("url") == "true" && value.Kind() == reflect.String {
-			str := value.String()
-			if str != "" {
-				_, err := url.ParseRequestURI(str)
-				if err != nil {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyURL, nil)})
-				}
-			}
-		}
-
-		// Boolean value check (must be true)
-		if field.Tag.Get("bool") == "true" && value.Kind() == reflect.Bool {
-			if !value.Bool() {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyBool, nil)})
-			}
-		}
-
-		// Zero value check
-		if field.Tag.Get("zero") == "true" {
-			if !isEmptyValue(value) {
-				errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyZero, nil)})
-			}
-		}
-
-		// Slice/Array length validation
-		if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
-			if minItems := field.Tag.Get("minItems"); minItems != "" {
-				min, err := strconv.Atoi(minItems)
-				if err == nil && value.Len() < min {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMinItems, min)})
-				}
-			}
-			if maxItems := field.Tag.Get("maxItems"); maxItems != "" {
-				max, err := strconv.Atoi(maxItems)
-				if err == nil && value.Len() > max {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyMaxItems, max)})
-				}
-			}
-		}
-
-		// String prefix/suffix/contains
-		if value.Kind() == reflect.String {
-			str := value.String()
-			if prefix := field.Tag.Get("prefix"); prefix != "" {
-				if !strings.HasPrefix(str, prefix) {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyPrefix, prefix)})
-				}
-			}
-			if suffix := field.Tag.Get("suffix"); suffix != "" {
-				if !strings.HasSuffix(str, suffix) {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeySuffix, suffix)})
-				}
-			}
-			if contains := field.Tag.Get("contains"); contains != "" {
-				if !strings.Contains(str, contains) {
-					errList = append(errList, FieldValidationError{Field: name, Err: getErr(TranslationKeyContains, contains)})
-				}
-			}
-		}
+		errList = append(errList,
+			validateRequired(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateMinMax(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateStep(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateLength(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validatePattern(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateURL(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateBool(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateZero(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateSliceArrayLength(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validatePrefixSuffixContains(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateValues(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateEmail(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateEnum(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateMapper(f, field, value, loc, getErr)...)
+		errList = append(errList,
+			validateSortedMapper(f, field, value, loc, getErr)...)
 	}
 	return errList
 }

--- a/validation.go
+++ b/validation.go
@@ -342,7 +342,11 @@ func (f *Form) validationErrorTranslated(loc Localizer, key string, args ...any)
 	return fmt.Sprintf(key, args...)
 }
 
-func (f *Form) ValidateForm(form any, loc Localizer) FieldErrors {
+func (f *Form) ValidateForm(form any) FieldErrors {
+	return f.ValidateFormLocalized(form, &DefaultLocalizer{})
+}
+
+func (f *Form) ValidateFormLocalized(form any, loc Localizer) FieldErrors {
 	errList := f.internalFormValidation(form, loc) // built-in validations
 
 	v := reflect.ValueOf(form)

--- a/validation_test.go
+++ b/validation_test.go
@@ -372,3 +372,76 @@ func TestValidateForm_Translation(t *testing.T) {
 		})
 	}
 }
+
+func TestExtendedValidations(t *testing.T) {
+	type ExtendedForm struct {
+		PatternField  string  `pattern:"^foo[0-9]+$"`
+		URLField      string  `url:"true"`
+		BoolField     bool    `bool:"true"`
+		ZeroInt       int     `zero:"true"`
+		ZeroString    string  `zero:"true"`
+		SliceField    []int   `minItems:"2" maxItems:"3"`
+		PrefixField   string  `prefix:"abc"`
+		SuffixField   string  `suffix:"xyz"`
+		ContainsField string  `contains:"mid"`
+		StepInt       int     `step:"5"`
+		StepFloat     float64 `step:"0.5"`
+		CustomMsg     string  `pattern:"^bar$" errorMsg:"custom error!"`
+	}
+
+	valid := ExtendedForm{
+		PatternField:  "foo123",
+		URLField:      "https://example.com",
+		BoolField:     true,
+		ZeroInt:       0,
+		ZeroString:    "",
+		SliceField:    []int{1, 2},
+		PrefixField:   "abcde",
+		SuffixField:   "wxyz",
+		ContainsField: "amidb",
+		StepInt:       10,
+		StepFloat:     2.0,
+		CustomMsg:     "bar",
+	}
+
+	cases := []struct {
+		name   string
+		form   ExtendedForm
+		errors int
+	}{
+		{"all valid", valid, 0},
+		{"pattern fail", func() ExtendedForm { f := valid; f.PatternField = "bar"; return f }(), 1},
+		{"url fail", func() ExtendedForm { f := valid; f.URLField = "notaurl"; return f }(), 1},
+		{"bool fail", func() ExtendedForm { f := valid; f.BoolField = false; return f }(), 1},
+		{"zero int fail", func() ExtendedForm { f := valid; f.ZeroInt = 1; return f }(), 1},
+		{"zero string fail", func() ExtendedForm { f := valid; f.ZeroString = "notzero"; return f }(), 1},
+		{"minItems fail", func() ExtendedForm { f := valid; f.SliceField = []int{1}; return f }(), 1},
+		{"maxItems fail", func() ExtendedForm { f := valid; f.SliceField = []int{1, 2, 3, 4}; return f }(), 1},
+		{"prefix fail", func() ExtendedForm { f := valid; f.PrefixField = "def"; return f }(), 1},
+		{"suffix fail", func() ExtendedForm { f := valid; f.SuffixField = "abc"; return f }(), 1},
+		{"contains fail", func() ExtendedForm { f := valid; f.ContainsField = "nope"; return f }(), 1},
+		{"step int fail", func() ExtendedForm { f := valid; f.StepInt = 7; return f }(), 1},
+		{"step float fail", func() ExtendedForm { f := valid; f.StepFloat = 2.1; return f }(), 1},
+		{"custom error msg", func() ExtendedForm { f := valid; f.CustomMsg = "baz"; return f }(), 1},
+	}
+
+	f := NewForm(nil)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			errList := f.internalFormValidation(&c.form, &DefaultLocalizer{})
+			if len(errList) != c.errors {
+				t.Errorf("expected %d errors, got %d: %+v", c.errors, len(errList), errList)
+			}
+			if c.name == "custom error msg" {
+				if len(errList) == 0 {
+					t.Errorf("expected at least one error for custom error msg case")
+				} else {
+					_, errMsg := errList[0].FieldError()
+					if !strings.Contains(errMsg, "custom error!") {
+						t.Errorf("expected custom error message, got: %s", errMsg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -181,7 +181,7 @@ func TestValidateForm_CustomValidation(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			errList := f.ValidateForm(&c.form, &DefaultLocalizer{})
+			errList := f.ValidateForm(&c.form)
 			if len(errList) != c.errors {
 				t.Errorf("expected %d errors, got %d: %+v", c.errors, len(errList), errList)
 			}
@@ -357,7 +357,7 @@ func TestValidateForm_Translation(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			errList := f.ValidateForm(&c.form, testLocalizer{Locale: c.locale})
+			errList := f.ValidateFormLocalized(&c.form, testLocalizer{Locale: c.locale})
 			found := false
 			for _, err := range errList {
 				_, fieldErr := err.FieldError()


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the form validation library, focusing on modularizing validation logic, adding a new `MapForm` utility for mapping HTTP form data to structs, and improving error handling. Additionally, it includes updates to templates and default configurations.

### Key Changes:

#### New Features:
* **`MapForm` Utility**: Added a new utility in `map.go` to map form values from an HTTP request to a struct, supporting nested structs and various data types. Includes error handling and comprehensive test coverage in `map_test.go`. [[1]](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840R1-R84) [[2]](diffhunk://#diff-20f420b07153864bdb8f2b3fbaea5c8477fa6d1235495f367dbc8e697e587bbbR1-R97)

#### Validation Enhancements:
* **Modularized Validation Logic**: Refactored `internalFormValidation` into multiple helper functions (e.g., `validateRequired`, `validateMinMax`, `validatePattern`) for better readability and maintainability. Added support for new validation tags like `pattern`, `url`, `bool`, `zero`, `minItems`, `maxItems`, `prefix`, `suffix`, and `contains`. [[1]](diffhunk://#diff-231c47682f843a7c87adef16dd53aa8aff733d6c2640eb2bbf54ba31d55a7838R24-R33) [[2]](diffhunk://#diff-231c47682f843a7c87adef16dd53aa8aff733d6c2640eb2bbf54ba31d55a7838L70-R202) [[3]](diffhunk://#diff-231c47682f843a7c87adef16dd53aa8aff733d6c2640eb2bbf54ba31d55a7838L110-R231)

#### Template Updates:
* **Removed Character Count Display**: Removed the max-length character count display from `textarea` templates for Bootstrap, Plain, and Tailwind frameworks. [[1]](diffhunk://#diff-5ebdfcb8ca55b02e4146fc04dc91ddeb5451f63e77d2544f9ac2e0d94106fcb3L74-L76) [[2]](diffhunk://#diff-bbe2ebc506f843b78c81d7e7609891724bb5969e3b332eefe765cbed538b02c9L72-L74) [[3]](diffhunk://#diff-7a605dd637801d90a5849984281cfd6595dd114c170cc4bc7d701b33ae7c6313L72-L74)

#### Default Configuration:
* **Default Submit Button Text**: Introduced `DefaultSubmitText` constant in `transformer.go` to provide a default label for submit buttons if none is specified. [[1]](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R29-R30) [[2]](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R97-R106)

#### Error Handling Improvements:
* **Template Error Handling**: Improved error handling in `form.go` for template parsing and execution, replacing `panic` with more descriptive error messages. [[1]](diffhunk://#diff-5b6a5ae74565d7ef9e9f413f5e0afd815515e98a7a11186b88ebe150ea90e7cdL88-R88) [[2]](diffhunk://#diff-5b6a5ae74565d7ef9e9f413f5e0afd815515e98a7a11186b88ebe150ea90e7cdL123-R131)