### PR TITLE
Form attributes & prepend & append at input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ See the example in `example/translation/main.go` for a complete usage demonstrat
 
 ---
 
+### Custom Form Attributes
+You can set custom HTML attributes on forms (e.g., `hx-post`, `data-*`, etc.) using the `Attributes` field in your form struct:
+
+```go
+form := &FormField{
+    // ...other fields...
+    Attributes: map[string]string{
+        "hx-post": "/some-url",
+        "data-custom": "value",
+    },
+}
+```
+
+### Input Groups (Prepend/Append)
+You can prepend or append content to input fields using the `group` tag. This is supported in all template sets (Plain, Bootstrap 5, Tailwind CSS):
+
+```go
+type ExampleForm struct {
+    Username string `form:"input,text" label:"Username" group:"@,.com"`
+}
+```
+This will render an input with `@` before and `.com` after the field, styled according to the selected template.
+
+---
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/example/templates/main.go
+++ b/example/templates/main.go
@@ -25,8 +25,8 @@ type (
 		// Basic input fields
 		Username string `form:"input,text" label:"Username" placeholder:"Enter your username" required:"true"`
 		Password string `form:"input,password" label:"Password" placeholder:"Enter your password" required:"true"`
-		Email    string `form:"input,email" label:"Email" placeholder:"Enter your email" required:"true"`
-		Phone    string `form:"input,tel" label:"Phone label" placeholder:"Enter your phone number"`
+		Email    string `form:"input,email" label:"Email" placeholder:"Enter your email" required:"true" group:"@"`
+		Phone    string `form:"input,tel" label:"Phone label" placeholder:"Enter your phone number" group:"&phone;"`
 		Age      int    `form:"input,number" label:"Age" placeholder:"Enter your age" step:"1"`
 		Birthday string `form:"input,date" label:"Birthday" placeholder:"Enter your birthday"`
 

--- a/example/translation/main.go
+++ b/example/translation/main.go
@@ -100,7 +100,7 @@ func main() {
 			data.Name = r.FormValue("Name")
 			data.Age, _ = strconv.Atoi(r.FormValue("Age"))
 
-			errList = f.ValidateForm(&data, loc)
+			errList = f.ValidateFormLocalized(&data, loc)
 		}
 
 		tmpl := template.Must(template.New("page").Funcs(f.FuncMap()).Parse(`

--- a/example/validation/main.go
+++ b/example/validation/main.go
@@ -42,7 +42,7 @@ type CustomForm struct {
 	form.Info
 	Name        string `form:"input,text" label:"Name" required:"true" minLength:"2" maxLength:"20"`
 	Color       string `form:"input,color" label:"Favorite Color (hex)" validate:"isHexColor"`
-	ColorManual string `form:"input,text" label:"Manual color input (hex)" validate:"isHexColor"`
+	ColorManual string `form:"input,text" label:"Manual color input (hex)" validate:"isHexColor" group:"before,after"`
 }
 
 func main() {

--- a/example/validation/main.go
+++ b/example/validation/main.go
@@ -40,8 +40,9 @@ func isHexColor(val any, field reflect.StructField) (out form.FieldErrors) {
 
 type CustomForm struct {
 	form.Info
-	Name  string `form:"input,text" label:"Name" required:"true" minLength:"2" maxLength:"20"`
-	Color string `form:"input,color" label:"Favorite Color (hex)" validate:"isHexColor"`
+	Name        string `form:"input,text" label:"Name" required:"true" minLength:"2" maxLength:"20"`
+	Color       string `form:"input,color" label:"Favorite Color (hex)" validate:"isHexColor"`
+	ColorManual string `form:"input,text" label:"Manual color input (hex)" validate:"isHexColor"`
 }
 
 func main() {
@@ -54,6 +55,9 @@ func main() {
 				Target:     r.URL.Path,
 				Method:     http.MethodPost,
 				SubmitText: "Submit",
+				Attributes: map[string]string{
+					"custom-attr": "value",
+				},
 			},
 		}
 
@@ -65,7 +69,7 @@ func main() {
 				return
 			}
 
-			errs = f.ValidateForm(&data, nil)
+			errs = f.ValidateForm(&data)
 		}
 
 		tmpl := template.Must(template.New("page").Funcs(f.FuncMap()).Parse(`

--- a/form.go
+++ b/form.go
@@ -28,9 +28,10 @@ type (
 	}
 
 	Info struct {
-		Target     string `json:"target,omitempty"`
-		Method     string `json:"method,omitempty"`
-		SubmitText string `json:"submit,omitempty"`
+		Target     string            `json:"target,omitempty"`
+		Method     string            `json:"method,omitempty"`
+		SubmitText string            `json:"submit,omitempty"`
+		Attributes map[string]string `json:"attributes,omitempty"`
 	}
 
 	Form struct {
@@ -100,6 +101,15 @@ func (f *Form) init(templateMap map[types.FieldType]map[types.InputFieldType]str
 					}
 
 					return key
+				},
+				"form_attributes": func(attributes map[string]string) template.HTMLAttr {
+					var sb strings.Builder
+					for k, v := range attributes {
+						if v != "" {
+							sb.WriteString(fmt.Sprintf(` %s="%s"`, k, template.HTMLEscapeString(v)))
+						}
+					}
+					return template.HTMLAttr(sb.String())
 				},
 				"baseInput": func(kv ...any) template.HTML {
 					if baseInputTpl == nil {

--- a/templates/bootstrapV5.go
+++ b/templates/bootstrapV5.go
@@ -6,6 +6,13 @@ var BootstrapV5 = map[types.FieldType]map[types.InputFieldType]string{
 	types.FieldTypeBase: {
 		types.InputFieldTypeNone: `<input type="{{.Type}}" id="{{.Field.Id}}" name="{{.Field.Name}}" value="{{.Field.Value}}" placeholder="{{ form_print .Loc .Field.Placeholder}}" {{if .Field.Required}}required{{end}} class="form-control" aria-labelledby="{{.Field.Id}}_label" {{if .Field.Description}}aria-describedby="{{.Field.Id}}_description"{{end}}>`,
 	},
+	types.FieldTypeInputGroup: {
+		types.InputFieldTypeNone: `<div class="input-group">
+  {{if .GroupBefore}}<div class="input-group-text">{{.GroupBefore}}</div>{{end}}
+  {{.Input}}
+  {{if .GroupAfter}}<div class="input-group-text">{{.GroupAfter}}</div>{{end}}
+</div>`,
+	},
 	types.FieldTypeInput: {
 		types.InputFieldTypeNone:          `{{ baseInput "Type" "text" "Field" .Field}}`,
 		types.InputFieldTypeText:          `{{ baseInput "Type" "text" "Field" .Field}}`,

--- a/templates/bootstrapV5.go
+++ b/templates/bootstrapV5.go
@@ -102,7 +102,7 @@ var BootstrapV5 = map[types.FieldType]map[types.InputFieldType]string{
 </div>`,
 	},
 	types.FieldTypeForm: {
-		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" class="mx-auto border rounded shadow-sm p-3" style="max-width: 32rem;" novalidate>
+		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" class="mx-auto border rounded shadow-sm p-3" style="max-width: 32rem;"  {{ if .Field.Attributes }}{{ form_attributes .Field.Attributes }}{{end}}>
   {{ fields }}
   <div class="d-grid gap-2 mt-3">
     <button type="submit" class="btn btn-primary btn-sm">{{ form_print .Loc .Field.Label }}</button>

--- a/templates/plain.go
+++ b/templates/plain.go
@@ -107,4 +107,11 @@ var Plain = map[types.FieldType]map[types.InputFieldType]string{
   </div>
 </form>`,
 	},
+	types.FieldTypeInputGroup: {
+		types.InputFieldTypeNone: `<div style="display: flex; align-items: stretch; width: 100%;">
+  {{if .GroupBefore}}<span style="display: inline-flex; align-items: center; padding: 0 0.75rem; background: #f8f9fa; border: 1px solid #ced4da; border-right: 0; border-radius: 0.25rem 0 0 0.25rem; color: #6c757d; font-size: 0.875rem;">{{.GroupBefore}}</span>{{end}}
+  {{.Input}}
+  {{if .GroupAfter}}<span style="display: inline-flex; align-items: center; padding: 0 0.75rem; background: #f8f9fa; border: 1px solid #ced4da; border-left: 0; border-radius: 0 0.25rem 0.25rem 0; color: #6c757d; font-size: 0.875rem;">{{.GroupAfter}}</span>{{end}}
+</div>`,
+	},
 }

--- a/templates/plain.go
+++ b/templates/plain.go
@@ -100,7 +100,7 @@ var Plain = map[types.FieldType]map[types.InputFieldType]string{
 </div>`,
 	},
 	types.FieldTypeForm: {
-		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" style="max-width: 32rem; margin: 0 auto; padding: 1rem; border: 1px solid #dee2e6; border-radius: 0.25rem; background-color: #fff; box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);" novalidate>
+		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" style="max-width: 32rem; margin: 0 auto; padding: 1rem; border: 1px solid #dee2e6; border-radius: 0.25rem; background-color: #fff; box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);" {{ if .Field.Attributes }}{{ form_attributes .Field.Attributes }}{{end}}>
   {{ fields }}
   <div style="margin-top: 1rem; text-align: right;">
     <button type="submit" style="display: inline-block; font-weight: 400; text-align: center; white-space: nowrap; vertical-align: middle; user-select: none; border: 1px solid transparent; padding: 0.375rem 0.75rem; font-size: 0.875rem; line-height: 1.5; border-radius: 0.25rem; color: #fff; background-color: #0d6efd; border-color: #0d6efd; cursor: pointer; transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;">{{ form_print .Loc .Field.Label }}</button>

--- a/templates/tailwindV3.go
+++ b/templates/tailwindV3.go
@@ -100,7 +100,7 @@ var TailwindV3 = map[types.FieldType]map[types.InputFieldType]string{
 </div>`,
 	},
 	types.FieldTypeForm: {
-		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" class="mx-auto max-w-md rounded-lg border border-gray-200 bg-white p-4 shadow-sm" novalidate>
+		types.InputFieldTypeNone: `<form action="{{.Field.Target}}" method="{{.Field.Method}}" class="mx-auto max-w-md rounded-lg border border-gray-200 bg-white p-4 shadow-sm" {{ if .Field.Attributes }}{{ form_attributes .Field.Attributes }}{{end}}>
   {{ fields }}
   <div class="mt-4 flex justify-end">
     <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed">{{ form_print .Loc .Field.Label }}</button>

--- a/templates/tailwindV3.go
+++ b/templates/tailwindV3.go
@@ -6,6 +6,13 @@ var TailwindV3 = map[types.FieldType]map[types.InputFieldType]string{
 	types.FieldTypeBase: {
 		types.InputFieldTypeNone: `<input type="{{.Type}}" id="{{.Field.Id}}" name="{{.Field.Name}}" value="{{.Field.Value}}" placeholder="{{ form_print .Loc .Field.Placeholder}}" {{if .Field.Required}}required{{end}} class="border border-gray-200 block w-full rounded-md px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" aria-labelledby="{{.Field.Id}}_label" {{if .Field.Description}}aria-describedby="{{.Field.Id}}_description"{{end}}>`,
 	},
+	types.FieldTypeInputGroup: {
+		types.InputFieldTypeNone: `<div class="flex rounded-md shadow-sm">
+  {{if .GroupBefore}}<span class="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 px-3 text-gray-500 text-sm">{{.GroupBefore}}</span>{{end}}
+  {{.Input}}
+  {{if .GroupAfter}}<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-gray-500 text-sm">{{.GroupAfter}}</span>{{end}}
+</div>`,
+	},
 	types.FieldTypeInput: {
 		types.InputFieldTypeNone:          `{{ baseInput "Type" "text" "Field" .Field}}`,
 		types.InputFieldTypeText:          `{{ baseInput "Type" "text" "Field" .Field}}`,

--- a/transformer.go
+++ b/transformer.go
@@ -106,6 +106,13 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 			Label:  label,
 		}
 
+		for k, v := range info.Attributes {
+			if formField.Attributes == nil {
+				formField.Attributes = make(map[string]string)
+			}
+			formField.Attributes[k] = v
+		}
+
 		fields = append(fields, formField)
 	}
 

--- a/transformer.go
+++ b/transformer.go
@@ -17,6 +17,7 @@ const (
 	tagLegend      = "legend"
 	tagValues      = "values"
 	tagForm        = "form"
+	tagGroup       = "group"
 	tagStep        = "step"
 	tagRows        = "rows"
 	tagCols        = "cols"
@@ -138,6 +139,19 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 			Description: tags.Get(tagDescription),
 			Name:        strings.Join(nname, "."),
 			Value:       rValue.Field(i).Interface(),
+		}
+
+		groupTag := tags.Get(tagGroup)
+		if groupTag != "" {
+			if strings.Contains(groupTag, ",") {
+				parts := strings.SplitN(groupTag, ",", 2)
+				field.GroupBefore = strings.TrimSpace(parts[0])
+				if len(parts) > 1 {
+					field.GroupAfter = strings.TrimSpace(parts[1])
+				}
+			} else {
+				field.GroupBefore = groupTag
+			}
 		}
 
 		formTag := tags.Get(tagForm)

--- a/types/types.go
+++ b/types/types.go
@@ -19,27 +19,28 @@ type FieldValue struct {
 
 // FormField represents a form field
 type FormField struct {
-	Type        FieldType      `json:"type"`
-	InputType   InputFieldType `json:"inputType,omitempty"`
-	Name        string         `json:"name"`
-	Id          string         `json:"id,omitempty"`
-	Label       string         `json:"label,omitempty"`
-	Value       interface{}    `json:"value,omitempty"`
-	Placeholder string         `json:"placeholder,omitempty"`
-	Description string         `json:"description,omitempty"`
-	Required    bool           `json:"required,omitempty"`
-	Hidden      bool           `json:"hidden,omitempty"`
-	Min         string         `json:"min,omitempty"`
-	Max         string         `json:"max,omitempty"`
-	MaxLength   string         `json:"maxLength,omitempty"`
-	Step        string         `json:"step,omitempty"`
-	Rows        string         `json:"rows,omitempty"`
-	Cols        string         `json:"cols,omitempty"`
-	Legend      string         `json:"legend,omitempty"`
-	Values      []FieldValue   `json:"values,omitempty"`
-	Fields      []FormField    `json:"fields,omitempty"`
-	Target      string         `json:"target,omitempty"`
-	Method      string         `json:"method,omitempty"`
+	Type        FieldType         `json:"type"`
+	InputType   InputFieldType    `json:"inputType,omitempty"`
+	Name        string            `json:"name"`
+	Id          string            `json:"id,omitempty"`
+	Label       string            `json:"label,omitempty"`
+	Value       interface{}       `json:"value,omitempty"`
+	Placeholder string            `json:"placeholder,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Required    bool              `json:"required,omitempty"`
+	Hidden      bool              `json:"hidden,omitempty"`
+	Min         string            `json:"min,omitempty"`
+	Max         string            `json:"max,omitempty"`
+	MaxLength   string            `json:"maxLength,omitempty"`
+	Step        string            `json:"step,omitempty"`
+	Rows        string            `json:"rows,omitempty"`
+	Cols        string            `json:"cols,omitempty"`
+	Legend      string            `json:"legend,omitempty"`
+	Values      []FieldValue      `json:"values,omitempty"`
+	Fields      []FormField       `json:"fields,omitempty"`
+	Target      string            `json:"target,omitempty"`
+	Method      string            `json:"method,omitempty"`
+	Attributes  map[string]string `json:"attributes,omitempty"`
 }
 
 // TemplateMap represents a map of field types to their input type templates

--- a/types/types.go
+++ b/types/types.go
@@ -41,6 +41,8 @@ type FormField struct {
 	Target      string            `json:"target,omitempty"`
 	Method      string            `json:"method,omitempty"`
 	Attributes  map[string]string `json:"attributes,omitempty"`
+	GroupBefore string            `json:"groupBefore,omitempty"`
+	GroupAfter  string            `json:"groupAfter,omitempty"`
 }
 
 // TemplateMap represents a map of field types to their input type templates
@@ -60,6 +62,7 @@ const (
 	FieldTypeLabel          FieldType = "label"
 	FieldTypeWrapper        FieldType = "wrapper"
 	FieldTypeForm           FieldType = "form"
+	FieldTypeInputGroup     FieldType = "inputgroup"
 )
 
 // Constants for input types


### PR DESCRIPTION
This pull request introduces enhancements to the form rendering library, adding support for custom HTML attributes and input groups (prepend/append content). These changes improve flexibility and styling for forms across different template sets (Plain, Bootstrap 5, Tailwind CSS). Below are the most significant updates:

### Custom HTML Attributes for Forms
* Added an `Attributes` field to the `FormField` struct, allowing users to specify custom HTML attributes (e.g., `hx-post`, `data-*`) for forms. (`[[1]](diffhunk://#diff-5b6a5ae74565d7ef9e9f413f5e0afd815515e98a7a11186b88ebe150ea90e7cdR34)`, `[[2]](diffhunk://#diff-f8d2bd35e1a8c9b86c8c4448dde00bc5480652f85ed0630efc012c3906d3a14fR43-R45)`)
* Introduced a `form_attributes` helper function to render these attributes in templates. (`[form.goR105-R113](diffhunk://#diff-5b6a5ae74565d7ef9e9f413f5e0afd815515e98a7a11186b88ebe150ea90e7cdR105-R113)`)
* Updated form templates (Plain, Bootstrap 5, Tailwind CSS) to include the custom attributes in the `<form>` tag. (`[[1]](diffhunk://#diff-5ebdfcb8ca55b02e4146fc04dc91ddeb5451f63e77d2544f9ac2e0d94106fcb3L105-R112)`, `[[2]](diffhunk://#diff-bbe2ebc506f843b78c81d7e7609891724bb5969e3b332eefe765cbed538b02c9L103-R116)`, `[[3]](diffhunk://#diff-7a605dd637801d90a5849984281cfd6595dd114c170cc4bc7d701b33ae7c6313L103-R110)`)

### Input Groups (Prepend/Append)
* Added `GroupBefore` and `GroupAfter` fields to the `FormField` struct, enabling content to be prepended or appended to input fields. (`[types/types.goR43-R45](diffhunk://#diff-f8d2bd35e1a8c9b86c8c4448dde00bc5480652f85ed0630efc012c3906d3a14fR43-R45)`)
* Introduced a new `FieldTypeInputGroup` type and corresponding templates for input groups in Plain, Bootstrap 5, and Tailwind CSS. (`[[1]](diffhunk://#diff-5ebdfcb8ca55b02e4146fc04dc91ddeb5451f63e77d2544f9ac2e0d94106fcb3R9-R15)`, `[[2]](diffhunk://#diff-bbe2ebc506f843b78c81d7e7609891724bb5969e3b332eefe765cbed538b02c9L103-R116)`, `[[3]](diffhunk://#diff-7a605dd637801d90a5849984281cfd6595dd114c170cc4bc7d701b33ae7c6313R9-R15)`)
* Updated the form rendering logic to wrap input fields in group templates when `GroupBefore` or `GroupAfter` is specified. (`[form.goL327-R365](diffhunk://#diff-5b6a5ae74565d7ef9e9f413f5e0afd815515e98a7a11186b88ebe150ea90e7cdL327-R365)`)

### Transformer Enhancements
* Added support for parsing the `group` tag in struct fields to populate `GroupBefore` and `GroupAfter` values. (`[transformer.goR144-R156](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R144-R156)`)
* Enhanced the `scanModel` function to include custom attributes in the transformed form fields. (`[transformer.goR110-R116](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R110-R116)`)

### Documentation Updates
* Updated `README.md` with examples demonstrating how to use custom attributes and input groups. (`[README.mdR171-R195](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R195)`)

### Minor Improvements
* Renamed `ValidateForm` to `ValidateFormLocalized` in the translation example for better clarity. (`[example/translation/main.goL103-R103](diffhunk://#diff-0e181ccf9da5f5b673974c54060734bd635380436011814c9697deb6e5e51595L103-R103)`)