### PR TITLE
pass Translate to the enum field so we can disable translation in cas…

### DIFF
--- a/transformer.go
+++ b/transformer.go
@@ -247,13 +247,13 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 			field.Disabled = true
 		}
 
+		// Check if translation is enabled: struct tag takes precedence over global default
+		tagValue := tags.Get(tagTranslate)
+		shouldTranslate := tagValue == "true" || (tagValue != "false" && DefaultEnumTranslation)
+
 		if rType.Field(i).Type.Implements(enumType) {
 			enums := reflect.New(rType.Field(i).Type).Interface().(Enumerator).Enum()
 			var fieldValue []types.FieldValue
-
-			// Check if translation is enabled: struct tag takes precedence over global default
-			tagValue := tags.Get(tagTranslate)
-			shouldTranslate := tagValue == "true" || (tagValue != "false" && DefaultEnumTranslation)
 
 			var typeName string
 			if shouldTranslate {
@@ -272,9 +272,10 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 					enumName = fmt.Sprintf("enum||%s.%s", typeName, val)
 				}
 				fieldValue = append(fieldValue, types.FieldValue{
-					Value:    val,
-					Name:     enumName,
-					Disabled: false,
+					Value:     val,
+					Name:      enumName,
+					Disabled:  false,
+					Translate: shouldTranslate,
 				})
 			}
 
@@ -328,11 +329,13 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 		if rType.Field(i).Type.Implements(mapperType) {
 			maps := rValue.Field(i).Interface().(Mapper).Mapper()
 			var fieldValue []types.FieldValue
+
 			for k, v := range maps {
 				fieldValue = append(fieldValue, types.FieldValue{
-					Value:    k,
-					Name:     v,
-					Disabled: false,
+					Value:     k,
+					Name:      v,
+					Disabled:  false,
+					Translate: shouldTranslate,
 				})
 			}
 
@@ -349,11 +352,13 @@ func (t *Transformer) scanModel(rValue reflect.Value, rType reflect.Type, names 
 		if rType.Field(i).Type.Implements(sortedMapperType) {
 			maps := rValue.Field(i).Interface().(SortedMapper).SortedMapper()
 			var fieldValue []types.FieldValue
+
 			for _, v := range maps {
 				fieldValue = append(fieldValue, types.FieldValue{
-					Value:    v.Key(),
-					Name:     v.Value(),
-					Disabled: false,
+					Value:     v.Key(),
+					Name:      v.Value(),
+					Disabled:  false,
+					Translate: shouldTranslate,
 				})
 			}
 

--- a/types/types.go
+++ b/types/types.go
@@ -12,9 +12,10 @@ func (i InputFieldType) String() string {
 
 // FieldValue represents a value in a dropdown or radio group
 type FieldValue struct {
-	Value    string `json:"value"`
-	Name     string `json:"name"`
-	Disabled bool   `json:"disabled"`
+	Value     string `json:"value"`
+	Name      string `json:"name"`
+	Disabled  bool   `json:"disabled"`
+	Translate bool   `json:"translate,omitempty"`
 }
 
 // FormField represents a form field


### PR DESCRIPTION
This pull request adds support for tracking whether enum, mapper, and sorted mapper values should be translated, by introducing a new `Translate` field to the `FieldValue` struct and updating its usage throughout the `Transformer` logic. This improves the flexibility and clarity of how translation is handled for form field values.

Enhancements for translation support:

* [`types/types.go`](diffhunk://#diff-f8d2bd35e1a8c9b86c8c4448dde00bc5480652f85ed0630efc012c3906d3a14fR18): Added a new `Translate` field to the `FieldValue` struct to indicate whether translation is enabled for a value.
* [`transformer.go`](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R278): Updated the logic in `scanModel` to set the `Translate` field for enum values, mapper values, and sorted mapper values according to the translation settings. ([transformer.goR278](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51R278), F157fdbfL329R329, F157fdbfL352R352)

Refactoring for clarity:

* [`transformer.go`](diffhunk://#diff-abf8e10e08c62f804e230ba3051ec87e80287cd1caf0cc8475cfc05921d87f51L250-R257): Refactored the handling of enum values to improve readability and maintainability.…e it for instance a name or entity that doesnt need translation